### PR TITLE
fix: convert port to string

### DIFF
--- a/tasks/print_db_credentials.yml
+++ b/tasks/print_db_credentials.yml
@@ -36,7 +36,7 @@
             +
             [
               "Here is your FreshRSS MySQL database information:
-              - database host: `" + freshrss_database_mysql_hostname + ":" + freshrss_database_mysql_port + "`
+              - database host: `" + freshrss_database_mysql_hostname + ":" + freshrss_database_mysql_port | string + "`
               - database username: `" + freshrss_database_mysql_username + "`
               - database password: `" + freshrss_database_mysql_password + "`
               - database name: `" + freshrss_database_name + "`

--- a/tasks/print_db_credentials.yml
+++ b/tasks/print_db_credentials.yml
@@ -66,7 +66,7 @@
             +
             [
               "Here is your FreshRSS Postgres database information:
-              - database host: `" + freshrss_database_hostname + ":" + freshrss_database_port + "`
+              - database host: `" + freshrss_database_hostname + ":" + freshrss_database_port | string + "`
               - database username: `" + freshrss_database_username + "`
               - database password: `" + freshrss_database_password + "`
               - database name: `" + freshrss_database_name + "`


### PR DESCRIPTION
Currently the task `print-freshrss-db-credentials` does not work and ends with this error:
```error
Task failed: Finalization of task args for 'ansible.builtin.set_fact' failed: Error while resolving value for 'devture_playbook_runtime_messages_list': Error rendering template: can only concatenate str (not \"_AnsibleTaggedInt\") to str
```

This PR fixes this bug, by converting the port to a string.